### PR TITLE
fix(libc): track allocation metadata in kernel

### DIFF
--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -14,6 +14,15 @@ use elf::endian::AnyEndian;
 pub static KERNEL_CR3: AtomicUsize = AtomicUsize::new(0);
 pub static NEXT_PROCESS_ID: AtomicUsize = AtomicUsize::new(1);
 
+#[repr(C)]
+struct HeapAllocationHeader {
+    magic: u64,
+    size: usize,
+}
+
+const HEAP_ALLOCATION_MAGIC: u64 = 0x4a4f535f48454150;
+const HEAP_ALLOCATION_HEADER_SIZE: usize = core::mem::size_of::<HeapAllocationHeader>();
+
 // stores a process' registers when it gets interrupted
 #[repr(C)]
 #[derive(Default, Clone)]
@@ -146,7 +155,6 @@ pub struct Process {
     working_directory: &'static str,
 
     file_handles: BTreeMap<u64, FileHandle>,
-    heap_allocations: BTreeMap<u64, usize>,
     next_handle_id: u64,
 
     parent_id: u64,
@@ -190,7 +198,6 @@ impl Process {
 
             working_directory: "/",
             file_handles: BTreeMap::new(),
-            heap_allocations: BTreeMap::new(),
             next_handle_id: 1,
 
             parent_id: 0,
@@ -211,7 +218,6 @@ impl Process {
         self.l4_page_map_l4_table = PageTable::default();
         self.heap_allocator = linked_list_allocator::LockedHeap::empty();
         self.file_handles = BTreeMap::new();
-        self.heap_allocations = BTreeMap::new();
         self.heap_l1_table_number = 0;
         self.heap_l2_table_number = 0;
         self.stack_page_counter = 0;
@@ -425,17 +431,24 @@ impl Process {
         let _event = core::hint::black_box(crate::instrument!());
 
         unsafe {
-            let alloc_size = size.max(1);
-            let layout = core::alloc::Layout::from_size_align_unchecked(alloc_size, 0x8);
+            let payload_size = size.max(1);
+            let total_size = payload_size
+                .checked_add(HEAP_ALLOCATION_HEADER_SIZE)
+                .expect("Heap allocation size overflow");
+            let layout = core::alloc::Layout::from_size_align_unchecked(total_size, 0x8);
 
             let success = false;
 
             while !success {
                 match self.heap_allocator.lock().allocate_first_fit(layout) {
                     Ok(address) => {
-                        let address = address.as_ptr() as u64;
-                        self.heap_allocations.insert(address, size);
-                        return address;
+                        let header_ptr = address.as_ptr() as *mut HeapAllocationHeader;
+                        header_ptr.write(HeapAllocationHeader {
+                            magic: HEAP_ALLOCATION_MAGIC,
+                            size,
+                        });
+
+                        return header_ptr.add(1) as u64;
                     }
                     Err(()) => {
                         //DEBUG!("Allocating userspace memory failed - attempting to increase heap size\n");
@@ -489,31 +502,55 @@ impl Process {
             }
 
             if new_size == 0 {
-                let stored_size = match self.heap_allocations.remove(&ptr) {
-                    Some(size) => size,
+                let header_ptr = match ptr.checked_sub(HEAP_ALLOCATION_HEADER_SIZE as u64) {
+                    Some(header_ptr) => header_ptr as *mut HeapAllocationHeader,
                     None => {
-                        ERROR!("Attempted to free unknown heap pointer\n");
+                        ERROR!("Attempted to free invalid heap pointer\n");
                         return 0;
                     }
                 };
 
-                let dealloc_layout = core::alloc::Layout::from_size_align_unchecked(stored_size.max(1), 0x8);
+                let header = &mut *header_ptr;
+                if header.magic != HEAP_ALLOCATION_MAGIC {
+                    ERROR!("Attempted to free unknown heap pointer\n");
+                    return 0;
+                }
+
+                let stored_size = header.size;
+                header.magic = 0;
+
+                let dealloc_size = stored_size
+                    .max(1)
+                    .checked_add(HEAP_ALLOCATION_HEADER_SIZE)
+                    .expect("Heap allocation size overflow");
+                let dealloc_layout = core::alloc::Layout::from_size_align_unchecked(dealloc_size, 0x8);
                 self.heap_allocator
                     .lock()
-                    .deallocate(core::ptr::NonNull::new_unchecked(ptr as *mut u8), dealloc_layout);
+                    .deallocate(core::ptr::NonNull::new_unchecked(header_ptr as *mut u8), dealloc_layout);
                 return 0;
             }
 
-            let old_size = match self.heap_allocations.get(&ptr).copied() {
-                Some(size) => size,
+            let old_header_ptr = match ptr.checked_sub(HEAP_ALLOCATION_HEADER_SIZE as u64) {
+                Some(header_ptr) => header_ptr as *mut HeapAllocationHeader,
                 None => {
-                    ERROR!("Attempted to realloc unknown heap pointer\n");
+                    ERROR!("Attempted to realloc invalid heap pointer\n");
                     return 0;
                 }
             };
 
+            let old_header = &mut *old_header_ptr;
+            if old_header.magic != HEAP_ALLOCATION_MAGIC {
+                ERROR!("Attempted to realloc unknown heap pointer\n");
+                return 0;
+            }
+
+            let old_size = old_header.size;
+
             let alloc_size = new_size.max(1);
-            let layout = core::alloc::Layout::from_size_align_unchecked(alloc_size, 0x8);
+            let total_size = alloc_size
+                .checked_add(HEAP_ALLOCATION_HEADER_SIZE)
+                .expect("Heap allocation size overflow");
+            let layout = core::alloc::Layout::from_size_align_unchecked(total_size, 0x8);
 
             /*
                 // SAFETY: the caller must ensure that the `new_size` does not overflow.
@@ -534,18 +571,26 @@ impl Process {
             let new_ptr = self.heap_allocator.lock().allocate_first_fit(layout);
 
             if new_ptr.is_ok() {
-                let new_address = new_ptr.unwrap().as_ptr() as u64;
+                let new_header_ptr = new_ptr.unwrap().as_ptr() as *mut HeapAllocationHeader;
+                new_header_ptr.write(HeapAllocationHeader {
+                    magic: HEAP_ALLOCATION_MAGIC,
+                    size: new_size,
+                });
+
+                let new_address = new_header_ptr.add(1) as u64;
 
                 core::ptr::copy_nonoverlapping(ptr as *const u8, new_address as *mut u8, old_size.min(new_size));
 
-                let old_size = self.heap_allocations.remove(&ptr).unwrap();
-                let old_layout = core::alloc::Layout::from_size_align_unchecked(old_size.max(1), 0x8);
+                old_header.magic = 0;
+                let old_total_size = old_size
+                    .max(1)
+                    .checked_add(HEAP_ALLOCATION_HEADER_SIZE)
+                    .expect("Heap allocation size overflow");
+                let old_layout = core::alloc::Layout::from_size_align_unchecked(old_total_size, 0x8);
 
                 self.heap_allocator
                     .lock()
-                    .deallocate(core::ptr::NonNull::new_unchecked(ptr as *mut u8), old_layout);
-
-                self.heap_allocations.insert(new_address, new_size);
+                    .deallocate(core::ptr::NonNull::new_unchecked(old_header_ptr as *mut u8), old_layout);
 
                 return new_address;
             }

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -16,11 +16,9 @@ pub static NEXT_PROCESS_ID: AtomicUsize = AtomicUsize::new(1);
 
 #[repr(C)]
 struct HeapAllocationHeader {
-    magic: u64,
     size: usize,
 }
 
-const HEAP_ALLOCATION_MAGIC: u64 = 0x4a4f535f48454150;
 const HEAP_ALLOCATION_HEADER_SIZE: usize = core::mem::size_of::<HeapAllocationHeader>();
 
 // stores a process' registers when it gets interrupted
@@ -443,10 +441,7 @@ impl Process {
                 match self.heap_allocator.lock().allocate_first_fit(layout) {
                     Ok(address) => {
                         let header_ptr = address.as_ptr() as *mut HeapAllocationHeader;
-                        header_ptr.write(HeapAllocationHeader {
-                            magic: HEAP_ALLOCATION_MAGIC,
-                            size,
-                        });
+                        header_ptr.write(HeapAllocationHeader { size: payload_size });
 
                         return header_ptr.add(1) as u64;
                     }
@@ -510,16 +505,10 @@ impl Process {
                     }
                 };
 
-                let header = &mut *header_ptr;
-                if header.magic != HEAP_ALLOCATION_MAGIC {
-                    ERROR!("Attempted to free unknown heap pointer\n");
-                    return 0;
-                }
+                let header = &*header_ptr;
 
-                let stored_size = header.size;
-                header.magic = 0;
-
-                let dealloc_size = stored_size
+                let dealloc_size = header
+                    .size
                     .max(1)
                     .checked_add(HEAP_ALLOCATION_HEADER_SIZE)
                     .expect("Heap allocation size overflow");
@@ -538,13 +527,8 @@ impl Process {
                 }
             };
 
-            let old_header = &mut *old_header_ptr;
-            if old_header.magic != HEAP_ALLOCATION_MAGIC {
-                ERROR!("Attempted to realloc unknown heap pointer\n");
-                return 0;
-            }
-
-            let old_size = old_header.size;
+            let old_header = &*old_header_ptr;
+            let old_size = old_header.size.max(1);
 
             let alloc_size = new_size.max(1);
             let total_size = alloc_size
@@ -572,18 +556,13 @@ impl Process {
 
             if new_ptr.is_ok() {
                 let new_header_ptr = new_ptr.unwrap().as_ptr() as *mut HeapAllocationHeader;
-                new_header_ptr.write(HeapAllocationHeader {
-                    magic: HEAP_ALLOCATION_MAGIC,
-                    size: new_size,
-                });
+                new_header_ptr.write(HeapAllocationHeader { size: alloc_size });
 
                 let new_address = new_header_ptr.add(1) as u64;
 
-                core::ptr::copy_nonoverlapping(ptr as *const u8, new_address as *mut u8, old_size.min(new_size));
+                core::ptr::copy_nonoverlapping(ptr as *const u8, new_address as *mut u8, old_size.min(alloc_size));
 
-                old_header.magic = 0;
                 let old_total_size = old_size
-                    .max(1)
                     .checked_add(HEAP_ALLOCATION_HEADER_SIZE)
                     .expect("Heap allocation size overflow");
                 let old_layout = core::alloc::Layout::from_size_align_unchecked(old_total_size, 0x8);

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -146,6 +146,7 @@ pub struct Process {
     working_directory: &'static str,
 
     file_handles: BTreeMap<u64, FileHandle>,
+    heap_allocations: BTreeMap<u64, usize>,
     next_handle_id: u64,
 
     parent_id: u64,
@@ -189,6 +190,7 @@ impl Process {
 
             working_directory: "/",
             file_handles: BTreeMap::new(),
+            heap_allocations: BTreeMap::new(),
             next_handle_id: 1,
 
             parent_id: 0,
@@ -209,6 +211,7 @@ impl Process {
         self.l4_page_map_l4_table = PageTable::default();
         self.heap_allocator = linked_list_allocator::LockedHeap::empty();
         self.file_handles = BTreeMap::new();
+        self.heap_allocations = BTreeMap::new();
         self.heap_l1_table_number = 0;
         self.heap_l2_table_number = 0;
         self.stack_page_counter = 0;
@@ -422,14 +425,17 @@ impl Process {
         let _event = core::hint::black_box(crate::instrument!());
 
         unsafe {
-            let layout = core::alloc::Layout::from_size_align_unchecked(size, 0x8);
+            let alloc_size = size.max(1);
+            let layout = core::alloc::Layout::from_size_align_unchecked(alloc_size, 0x8);
 
             let success = false;
 
             while !success {
                 match self.heap_allocator.lock().allocate_first_fit(layout) {
                     Ok(address) => {
-                        return address.as_ptr() as u64;
+                        let address = address.as_ptr() as u64;
+                        self.heap_allocations.insert(address, size);
+                        return address;
                     }
                     Err(()) => {
                         //DEBUG!("Allocating userspace memory failed - attempting to increase heap size\n");
@@ -482,16 +488,32 @@ impl Process {
                 return self.malloc(new_size);
             }
 
-            let layout = core::alloc::Layout::from_size_align_unchecked(new_size, 0x8);
-
             if new_size == 0 {
-                let stored_size = core::ptr::read_unaligned(ptr as *const u64) as usize;
-                let dealloc_layout = core::alloc::Layout::from_size_align_unchecked(stored_size + 8, 0x8);
+                let stored_size = match self.heap_allocations.remove(&ptr) {
+                    Some(size) => size,
+                    None => {
+                        ERROR!("Attempted to free unknown heap pointer\n");
+                        return 0;
+                    }
+                };
+
+                let dealloc_layout = core::alloc::Layout::from_size_align_unchecked(stored_size.max(1), 0x8);
                 self.heap_allocator
                     .lock()
                     .deallocate(core::ptr::NonNull::new_unchecked(ptr as *mut u8), dealloc_layout);
                 return 0;
             }
+
+            let old_size = match self.heap_allocations.get(&ptr).copied() {
+                Some(size) => size,
+                None => {
+                    ERROR!("Attempted to realloc unknown heap pointer\n");
+                    return 0;
+                }
+            };
+
+            let alloc_size = new_size.max(1);
+            let layout = core::alloc::Layout::from_size_align_unchecked(alloc_size, 0x8);
 
             /*
                 // SAFETY: the caller must ensure that the `new_size` does not overflow.
@@ -514,11 +536,16 @@ impl Process {
             if new_ptr.is_ok() {
                 let new_address = new_ptr.unwrap().as_ptr() as u64;
 
-                core::ptr::copy_nonoverlapping(ptr as *const u8, new_address as *mut u8, new_size);
+                core::ptr::copy_nonoverlapping(ptr as *const u8, new_address as *mut u8, old_size.min(new_size));
+
+                let old_size = self.heap_allocations.remove(&ptr).unwrap();
+                let old_layout = core::alloc::Layout::from_size_align_unchecked(old_size.max(1), 0x8);
 
                 self.heap_allocator
                     .lock()
-                    .deallocate(core::ptr::NonNull::new_unchecked(ptr as *mut u8), layout);
+                    .deallocate(core::ptr::NonNull::new_unchecked(ptr as *mut u8), old_layout);
+
+                self.heap_allocations.insert(new_address, new_size);
 
                 return new_address;
             }

--- a/userland/usr/libc.c
+++ b/userland/usr/libc.c
@@ -89,31 +89,19 @@ void draw_pixel(uint32_t x, uint32_t y, uint8_t color) {
 // Allocate memory
 void *malloc(long unsigned int size) {
   uint64_t address;
-  if (size > ((size_t)-1) - 8) {
-    return NULL;
-  }
-
-  // Allocation includes 8 bytes for the size header
-  uint64_t total_size = size + 8;
-  DO_SYSCALL(4, address, total_size, 0, 0);
+  DO_SYSCALL(4, address, size, 0, 0);
 
   if (address == 0) return NULL;
 
-  uint64_t *ptr = (uint64_t *)address;
-  *ptr = size; // Store the original size in the header
-  return (void *)(address + 8);
+  return (void *)address;
 }
 
 // Free memory
 void free(void *address) {
   if (address == NULL) return;
 
-  uint64_t base_address = (uint64_t)address - 8;
-
-  // The kernel reads the stored size header at base_address to deallocate the
-  // original allocation.
   uint64_t result;
-  DO_SYSCALL(20, result, base_address, 0, 0);
+  DO_SYSCALL(20, result, (uintptr_t)address, 0, 0);
 }
 
 // Open a file
@@ -1336,18 +1324,13 @@ void *realloc(void *ptr, size_t size) {
     return NULL;
   }
 
-  // For simplicity, we won't track the original size of ptr.
-  // We'll just allocate new memory and copy a fixed amount.
-  void *new_ptr = malloc(size);
-  if (new_ptr == NULL) {
+  uint64_t new_ptr;
+  DO_SYSCALL(20, new_ptr, (uintptr_t)ptr, size, 0);
+  if (new_ptr == 0) {
     return NULL;
   }
 
-  size_t old_size = *((uint64_t *)((uint8_t *)ptr - 8));
-  size_t copy_size = size < old_size ? size : old_size;
-  memcpy(new_ptr, ptr, copy_size);
-  free(ptr);
-  return new_ptr;
+  return (void *)new_ptr;
 }
 
 char *setlocale(int category, const char *locale) {


### PR DESCRIPTION
## Summary
- Kernel allocations now keep the allocation size in a small header directly before the payload.
- `malloc()` reserves header + payload and returns the payload pointer.
- `free()` and `realloc()` walk back to the header, read the stored size, and deallocate accordingly.
- The separate allocation-metadata map is gone.
- The magic-number check was removed to keep the implementation simple for now.

## Notes
- `realloc()` still copies `min(old_size, new_size)`.
- Userland `malloc/free/realloc` remain thin syscalls.

## Verification
- `git diff --check`
- `gcc -fsyntax-only -Iuserland/usr/include -Iuserland/usr -fno-builtin -std=gnu11 userland/usr/libc.c`