### PR TITLE
fix(libc): use size headers for malloc/free

### DIFF
--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -485,9 +485,11 @@ impl Process {
             let layout = core::alloc::Layout::from_size_align_unchecked(new_size, 0x8);
 
             if new_size == 0 {
+                let stored_size = core::ptr::read_unaligned(ptr as *const u64) as usize;
+                let dealloc_layout = core::alloc::Layout::from_size_align_unchecked(stored_size + 8, 0x8);
                 self.heap_allocator
                     .lock()
-                    .deallocate(core::ptr::NonNull::new_unchecked(ptr as *mut u8), layout);
+                    .deallocate(core::ptr::NonNull::new_unchecked(ptr as *mut u8), dealloc_layout);
                 return 0;
             }
 

--- a/userland/usr/libc.c
+++ b/userland/usr/libc.c
@@ -89,13 +89,28 @@ void draw_pixel(uint32_t x, uint32_t y, uint8_t color) {
 // Allocate memory
 void *malloc(long unsigned int size) {
   uint64_t address;
-  DO_SYSCALL(4, address, size, 0, 0); // Only size is passed
-  return (void *)address;
+  // Allocation includes 8 bytes for the size header
+  uint64_t total_size = size + 8;
+  DO_SYSCALL(4, address, total_size, 0, 0);
+  
+  if (address == 0) return NULL;
+
+  uint64_t *ptr = (uint64_t *)address;
+  *ptr = size; // Store the original size in the header
+  return (void *)(address + 8);
 }
 
-// Free memory (currently does nothing) --> leaks memory
+// Free memory
 void free(void *address) {
-  // TODO: Implement the free function
+  if (address == NULL) return;
+
+  uint64_t base_address = (uint64_t)address - 8;
+  uint64_t original_size = *(uint64_t *)base_address;
+
+  // Utilize realloc syscall (20) with size 0 to trigger deallocation in kernel
+  // The kernel realloc implementation requires the pointer and the new size (0)
+  uint64_t result;
+  DO_SYSCALL(20, result, base_address, 0, 0);
 }
 
 // Open a file

--- a/userland/usr/libc.c
+++ b/userland/usr/libc.c
@@ -89,10 +89,14 @@ void draw_pixel(uint32_t x, uint32_t y, uint8_t color) {
 // Allocate memory
 void *malloc(long unsigned int size) {
   uint64_t address;
+  if (size > ((size_t)-1) - 8) {
+    return NULL;
+  }
+
   // Allocation includes 8 bytes for the size header
   uint64_t total_size = size + 8;
   DO_SYSCALL(4, address, total_size, 0, 0);
-  
+
   if (address == 0) return NULL;
 
   uint64_t *ptr = (uint64_t *)address;
@@ -105,10 +109,9 @@ void free(void *address) {
   if (address == NULL) return;
 
   uint64_t base_address = (uint64_t)address - 8;
-  uint64_t original_size = *(uint64_t *)base_address;
 
-  // Utilize realloc syscall (20) with size 0 to trigger deallocation in kernel
-  // The kernel realloc implementation requires the pointer and the new size (0)
+  // The kernel reads the stored size header at base_address to deallocate the
+  // original allocation.
   uint64_t result;
   DO_SYSCALL(20, result, base_address, 0, 0);
 }
@@ -1340,7 +1343,9 @@ void *realloc(void *ptr, size_t size) {
     return NULL;
   }
 
-  memcpy(new_ptr, ptr, size);
+  size_t old_size = *((uint64_t *)((uint8_t *)ptr - 8));
+  size_t copy_size = size < old_size ? size : old_size;
+  memcpy(new_ptr, ptr, copy_size);
   free(ptr);
   return new_ptr;
 }


### PR DESCRIPTION
## Summary
- Rebasing `feature/libc-malloc-free` onto `master`.
- `malloc()` reserves a small header before the payload and stores the allocation size there.
- `free()` and `realloc()` walk back to that header, read the stored size, and deallocate/copy accordingly.
- Userland `malloc/free/realloc` remain thin syscall wrappers.

## Verification
- `git diff --check`
- `gcc -fsyntax-only -Iuserland/usr/include -Iuserland/usr -fno-builtin -std=gnu11 userland/usr/libc.c`
